### PR TITLE
fix: remove beta version from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-beta.0"
+    "@rsbuild/core": "1.x"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {


### PR DESCRIPTION
Remove `@rsbuild/core` beta version from peerDependencies