### PR TITLE
chore: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,24 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Pnpm
-        run: npm i -g corepack@latest --force && corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
+
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Install Dependencies
         run: pnpm install
@@ -35,7 +41,7 @@ jobs:
       - name: Publish
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.RSBUILD_PLUGIN_NPM_TOKEN }}
+          token: empty
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "packageManager": "pnpm@10.14.0",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
-    "provenance": true
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers