### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-rem",
   "version": "1.0.6",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-rem",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-rem#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-rem/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the project README
- add npm bugs metadata pointing to the GitHub issues page

## Why
The currently published @rsbuild/plugin-rem package exposes its name, version, and repository on npm, but not homepage or bugs links. Adding these fields makes it easier for npm/package consumers to find documentation and report issues directly from package metadata.

## Validation
- `node -e "const pkg=require('./package.json'); if(pkg.homepage!=='https://github.com/rstackjs/rsbuild-plugin-rem#readme') throw new Error('bad homepage'); if(!pkg.bugs || pkg.bugs.url!=='https://github.com/rstackjs/rsbuild-plugin-rem/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({homepage:pkg.homepage,bugs:pkg.bugs}, null, 2));"`
- `npm view @rsbuild/plugin-rem@latest name version repository.url homepage bugs --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`