### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -426,6 +429,9 @@ packages:
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -992,6 +998,8 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from '@rstest/playwright';
 import { createRsbuild } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginRem } from '../../dist';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -15,7 +15,7 @@ test('should convert rem unit correctly', async ({ page }) => {
     rsbuildConfig: {
       plugins: [pluginRem(), pluginReact()],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });
@@ -100,7 +100,7 @@ test('should apply crossorigin to rem runtime script', async ({ page }) => {
         pluginReact(),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
       html: {
         crossorigin: 'use-credentials',
@@ -141,7 +141,7 @@ test('should apply html.scriptLoading to rem runtime script', async ({
         pluginReact(),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
       html: {
         scriptLoading: 'module',

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';


### PR DESCRIPTION
This PR replaces the local random-port helper with `@rstackjs/test-utils` so test servers verify port availability through the shared ecosystem implementation. Call sites now await the asynchronous helper.